### PR TITLE
Add missing require statement to prevent Digest::SHA1 from throwing

### DIFF
--- a/lib/kameleon/step.rb
+++ b/lib/kameleon/step.rb
@@ -1,3 +1,5 @@
+require 'digest'
+
 module Kameleon
 
   class Command


### PR DESCRIPTION
In ruby2.3 the following works (require 'securerandom' exists somewhere in the kameleon code):
```
graphene-99 ~ $ /usr/bin/ruby2.3
require 'securerandom'
@x=Digest::SHA1.hexdigest("A")
graphene-99 ~ $ exit
```
while with ruby2.5 it doesn't:
```
tartare ~ $ ruby2.5
require 'securerandom'
@x=Digest::SHA1.hexdigest("A")
Traceback (most recent call last):
-:2:in `<main>': uninitialized constant Digest (NameError)
tartare ~ $ 
```

As a consequence, the present kameleon source code cannot complete the ctor of the Command class in step.rb ; an additional "require" statement seems to be required. A symptom is that a command such as `kameleon template list`, without the change, might fail to list everything.