### PR TITLE
Allow use of $kameleon_data_dir on its own

### DIFF
--- a/lib/kameleon/utils.rb
+++ b/lib/kameleon/utils.rb
@@ -21,7 +21,7 @@ module Kameleon
       raw.to_s.scan(/\$\$kameleon\_data\_dir\/(.*)/) do |var|
         warn_var(var)
       end
-      reg = %r/(\$\$kameleon\_data\_dir|\$\${kameleon\_data\_dir})(.*)/
+      reg = %r/(\$\$kameleon\_data\_dir|\$\${kameleon\_data\_dir})((\S|\\\s)*)/
       matches = raw.to_enum(:scan, reg).map { Regexp.last_match }
       matches.each do |m|
         unless m.nil?


### PR DESCRIPTION
This commit fixes the regex replacing $kameleon_data_dir to stop on whitespaces (as defined by \s) instead of blindly matching everything that follows.

This is an attempt to adress #124.