### PR TITLE
doc: update dryrun command with dryrun option

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -276,9 +276,9 @@ output with every information about one or possibly several recipes. For instanc
      -> user_password: kameleon
 
 You can also inspect the steps involed in your recipe using either 
-``kameleon dryrun``, or ``kameleon dag``.
+``kameleon build --dryrun``, or ``kameleon dag``.
 
-``kameleon dryrun`` run through the sections and steps that the ``kameleon build`` will actually execute.
+``kameleon build --dryrun`` run through the sections and steps that the ``kameleon build`` will actually execute.
 
 ``kameleon dag`` draws a direct acyclic graph of a recipe inheritance and steps for one or possibly many recipes all at once. The DAG can be converted to a image or pdf file when using either the ``--file`` or ``--format`` option.
 

--- a/erb/extend.yaml.erb
+++ b/erb/extend.yaml.erb
@@ -6,7 +6,7 @@
 #
 #==============================================================================
 # This recipe extends another. To look at the step involed, run:
-#   kameleon dryrun <%= recipe_name %>
+#   kameleon build --dryrun <%= recipe_name %>
 # To see the variables that you can override, use the following command:
 #   kameleon info <%= recipe_name %>
 ---


### PR DESCRIPTION
The dryrun command was removed in 2.10.11 and replaced with the --dryrun option for the build command.

This commit is part of work done for a project from Google Summer of Code, see the project details at
<https://summerofcode.withgoogle.com/programs/2024/projects/E9Jp7RUx>.